### PR TITLE
fix: select bigscape cutoff, default is 0.3

### DIFF
--- a/scripts/source_template.py
+++ b/scripts/source_template.py
@@ -60,7 +60,12 @@ def create_dbt_source_config(
                 ] = template_location
             else:
                 logging.warning(f"More than 1 table is found! {table}")
-                raise
+                try:
+                    logging.info(f"Getting table within cutoff: {bigscape_cutoff}")
+                    table = [i for i in table if bigscape_cutoff in str(i)]
+                    logging.debug(str(table))
+                except:
+                    raise
             logging.debug("Moving on...")
 
     logging.info(f"Writing to output: {outfile}")


### PR DESCRIPTION
Handles error:
```
WARNING  21/12 08:12:28   More than 1 table is found! [PosixPath('data/processed/hq_saccharopolyspora/dbt_as_6.1.1/../bigscape/for_cytoscape_antismash_6.1.1/2022-12-21 02_21_01_df_clusters_0.30.csv'), PosixPath('data/processed/hq_saccharopolyspora/dbt_as_6.1.1/../bigscape/for_cytoscape_antismash_6.1.1/2022-12-21 02_21_01_df_clusters_0.40.csv'), PosixPath('data/processed/hq_saccharopolyspora/dbt_as_6.1.1/../bigscape/for_cytoscape_antismash_6.1.1/2022-12-21 02_21_01_df_clusters_0.50.csv')]
Traceback (most recent call last):
  File "/datadrive/bgcflow/data/processed/hq_saccharopolyspora/dbt_as_6.1.1/scripts/source_template.py", line 76, in <module>
    create_dbt_source_config(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
  File "/datadrive/bgcflow/data/processed/hq_saccharopolyspora/dbt_as_6.1.1/scripts/source_template.py", line 63, in create_dbt_source_config
    raise
RuntimeError: No active exception to reraise
```