### PR TITLE
feat: write tables to bgcflow schema instead of main

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'dbt_bgcflow'
-version: '1.0.0'
+version: '0.4.0'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/profiles.yml
+++ b/profiles.yml
@@ -4,6 +4,7 @@ dbt_bgcflow:
     dev:
       type: duckdb
       path: 'dbt_bgcflow.duckdb'
+      schema: bgcflow
       threads: 2
       extensions:
         - parquet


### PR DESCRIPTION
This PR moves the schema from `main` to `bgcflow`. Therefore the tables can be accessed from `bgcflow.cdss` etc